### PR TITLE
feature/56-improve-the-tree-component

### DIFF
--- a/apps/lumina-core/src/components/lumina-action-buttons/move/lumina-move-component.tsx
+++ b/apps/lumina-core/src/components/lumina-action-buttons/move/lumina-move-component.tsx
@@ -9,7 +9,8 @@ type TProps = {
 
 export const MoveComponentButton = ({ id, dispatch, moveDirection }: TProps) => {
   const direction = moveDirection === "up" // more user friendly to use string and transform to boolean
-  const handleOnClickMoveUp = useCallback(() => {
+  const handleOnClickMoveUp = useCallback((event:any) => {
+    event.stopPropagation()
     dispatch({
       type: "moveUpComponent",
       data: {
@@ -20,7 +21,8 @@ export const MoveComponentButton = ({ id, dispatch, moveDirection }: TProps) => 
     [dispatch, id]
   )
 
-  const handleOnClickMoveDown = useCallback(() => {
+  const handleOnClickMoveDown = useCallback((event: any) => {
+    event.stopPropagation()
     dispatch({
       type: "moveDownComponent",
       data: {


### PR DESCRIPTION
1. added on /move/lumina-move-component on the handleOnClick callBack for move up and down a stopPropagation event, seems to sort out the issue of expanding the children components