### PR TITLE
bugfix/76-Remove-all-routing-from-Lumina

### DIFF
--- a/examples/vite-react/package.json
+++ b/examples/vite-react/package.json
@@ -14,7 +14,8 @@
   "dependencies": {
     "classnames": "^2.5.1",
     "react": "^18.3.1",
-    "react-dom": "^18.3.1"
+    "react-dom": "^18.3.1",
+    "react-router-dom": "^6.26.1"
   },
   "devDependencies": {
     "@lumina/core": "workspace:*",
@@ -24,16 +25,16 @@
     "@typescript-eslint/parser": "^7.15.0",
     "@vitejs/plugin-react": "^4.3.1",
     "eslint": "^8.57.0",
-    "eslint-plugin-react-hooks": "^4.6.2",
-    "eslint-plugin-react-refresh": "^0.4.7",
-    "eslint-plugin-react": "^7.35.0",
     "eslint-config-prettier": "^9.1.0",
     "eslint-plugin-prettier": "^5.2.1",
+    "eslint-plugin-react": "^7.35.0",
+    "eslint-plugin-react-hooks": "^4.6.2",
+    "eslint-plugin-react-refresh": "^0.4.7",
+    "globals": "^15.8.0",
     "husky": "^9.1.4",
     "lint-staged": "^15.2.7",
-    "globals": "^15.8.0",
-    "typescript": "^5.2.2",
     "prettier": "^3.3.3",
+    "typescript": "^5.2.2",
     "vite": "^5.3.4"
   },
   "lint-staged": {

--- a/examples/vite-react/src/App.tsx
+++ b/examples/vite-react/src/App.tsx
@@ -2,9 +2,25 @@ import Lumina from '@lumina/core'
 import '@lumina/core/style.css'
 import { getFullData } from './lib/dataFetcher'
 import luminaConfig from './luminaComponents/config'
+import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
 function App() {
-  return <Lumina getData={getFullData} selectedPage='home' components={luminaConfig} />
+  return (
+    <BrowserRouter>
+      <Routes>
+        <Route
+          index
+          element={<Lumina getData={getFullData} selectedPage='home' components={luminaConfig} />}
+        />
+        <Route
+          path='/editor'
+          element={
+            <Lumina getData={getFullData} selectedPage='home' components={luminaConfig} isEditor />
+          }
+        />
+      </Routes>
+    </BrowserRouter>
+  )
 }
 
 export default App

--- a/packages/lumina-core/package.json
+++ b/packages/lumina-core/package.json
@@ -43,7 +43,6 @@
     "prettier": "^3.3.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^6.26.1",
     "rimraf": "^6.0.1",
     "style-dictionary": "^4.0.1",
     "stylelint": "^16.8.1",

--- a/packages/lumina-core/src/main.tsx
+++ b/packages/lumina-core/src/main.tsx
@@ -8,8 +8,6 @@ import { useEffect, useState } from 'react'
 import type { TConfig } from './models/editor-buttonModel'
 import { ToggleModalContextProvider } from './context/handleModalsContext'
 import { EditorModal } from './components/modals'
-import { FormThemeProvider } from 'react-form-component'
-import { BrowserRouter, Route, Routes } from 'react-router-dom'
 
 export type TComponentConfig = {
   [key: string]: {
@@ -22,12 +20,14 @@ type TProps = {
   selectedPage: string
   getData: () => Promise<IData>
   components: TComponentConfig
+  isEditor?: boolean
 }
 
 const defaultValues: TProps = {
   selectedPage: 'home',
   getData: async () => ({}),
   components: {},
+  isEditor: false,
 }
 
 let componentConfig: TComponentConfig = {}
@@ -41,7 +41,12 @@ function setComponentConfig(newComponentConfig: TComponentConfig) {
   return componentConfig
 }
 
-export default function Lumina({ selectedPage, getData, components }: TProps = defaultValues) {
+export default function Lumina({
+  selectedPage,
+  getData,
+  components,
+  isEditor = false,
+}: TProps = defaultValues) {
   const [builderData, setBuilderData] = useState<IData>({})
 
   useEffect(() => {
@@ -62,10 +67,11 @@ export default function Lumina({ selectedPage, getData, components }: TProps = d
   }, [components])
 
   if (!builderData[selectedPage]) return null
+
   return (
     <ContextProvider
       data={{
-        appContext: { editor: true },
+        appContext: { editor: isEditor },
         builderDataContext: {
           builderData,
           selectedPage,
@@ -73,24 +79,16 @@ export default function Lumina({ selectedPage, getData, components }: TProps = d
         },
       }}
     >
-      <FormThemeProvider theme={{ colors: { success: 'none' } }}>
+      {isEditor ? (
         <ToggleModalContextProvider>
-          <BrowserRouter>
-            <Routes>
-              <Route index element={<Render />} />
-              <Route
-                path='/editor'
-                element={
-                  <Editor>
-                    <EditorModal />
-                    <Render />
-                  </Editor>
-                }
-              />
-            </Routes>
-          </BrowserRouter>
+          <Editor>
+            <EditorModal />
+            <Render />
+          </Editor>
         </ToggleModalContextProvider>
-      </FormThemeProvider>
+      ) : (
+        <Render />
+      )}
     </ContextProvider>
   )
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
+      react-router-dom:
+        specifier: ^6.26.1
+        version: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
       '@lumina/core':
         specifier: workspace:*
@@ -194,9 +197,6 @@ importers:
       react-dom:
         specifier: ^18.3.1
         version: 18.3.1(react@18.3.1)
-      react-router-dom:
-        specifier: ^6.26.1
-        version: 6.26.1(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       rimraf:
         specifier: ^6.0.1
         version: 6.0.1


### PR DESCRIPTION
#76 

- Removed the lib react-router-dom from /packages/lumina-core/src/main.tsx and updated the code there
- Added the lib react-router-dom on /examples/vite-react/src/App.tsx

Routing is now working as expected.